### PR TITLE
Update linter.yml

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
         
       - name: Lint Code Base
-        uses: docker://github/super-linter:v3
+        uses: github/super-linter@v3
         env:
           PYTHON_PYLINT_CONFIG_FILE: .pylintrc
           VALIDATE_ALL_CODEBASE: false


### PR DESCRIPTION
I have made the changes as propsed in #86 by @dlebauer for uses: `github/super-linter@3` vs `docker://github/super-linter:v3` but still it doesn't seem to fix this. Any thoughts what should we do?
